### PR TITLE
Using the parent container width property instead of theOrgchart elem…

### DIFF
--- a/streamlit_hierarchy_chart/__init__.py
+++ b/streamlit_hierarchy_chart/__init__.py
@@ -36,7 +36,7 @@ else:
     # build directory:
     parent_dir = os.path.dirname(os.path.abspath(__file__))
     build_dir = os.path.join(parent_dir, "frontend/dist")
-    print(build_dir)
+
     _component_func = components.declare_component(
         "hierarchy_chart",
         path=build_dir

--- a/streamlit_hierarchy_chart/frontend/src/components/OrgChart.vue
+++ b/streamlit_hierarchy_chart/frontend/src/components/OrgChart.vue
@@ -78,11 +78,12 @@ export default defineComponent({
       if (el === null){
         return
       }
-      const orgChartElement = document.querySelector('.p-organizationchart-table') as HTMLElement
-      if (orgChartElement === null){
-        return
-      }
-      const widthx = orgChartElement.offsetWidth +50
+      // const orgChartElement = document.querySelector('.p-organizationchart-table') as HTMLElement
+      // if (orgChartElement === null){
+      //   return
+      // }
+      const widthx = el.offsetWidth +50
+      // console.log(widthx)
       html2canvas(el,{scale:3,width:widthx,backgroundColor:'#EDEADE'}).then(canvas => {
         this.screenShot = canvas.toDataURL("image/png");
         const link = document.createElement('a');


### PR DESCRIPTION
Using the parent container width property instead of theOrgchart element to stop image overflow hidden